### PR TITLE
Removed the need for creating UmbracoHelper instance

### DIFF
--- a/Our.Umbraco.PropertyConverters/Models/RelatedLink.cs
+++ b/Our.Umbraco.PropertyConverters/Models/RelatedLink.cs
@@ -151,8 +151,7 @@ namespace Our.Umbraco.PropertyConverters.Models
                             return null;
                         }
 
-                        var umbHelper = new UmbracoHelper(UmbracoContext.Current);
-                        this._link = umbHelper.NiceUrl(this._linkItem.Value<int>("internal"));
+                        this._link = UmbracoContext.Current.UrlProvider.GetUrl(this._linkItem.Value<int>("internal"));
                         if (this._link.Equals("#"))
                         {
                             this._linkDeleted = true;


### PR DESCRIPTION
The `UmbracoHelper` instance was only being used to call `NiceUrl`.  Following this through the Umbraco Core code, `NiceUrl` is a wrapper for `Url`, which in turn is a wrapper for `UrlProvider.GetUrl`.  Since the `UrlProvider` is accessible from `UmbracoContext`, it is quicker to go direct.
